### PR TITLE
fix - ibm-namespace-scope-operator-cluster-scoped chart url

### DIFF
--- a/5.2.0/index.yaml
+++ b/5.2.0/index.yaml
@@ -103,7 +103,7 @@ entries:
     - https://github.com/IBM/ibm-namespace-scope-operator
     type: application
     urls:
-    - https://raw.github.com/IBM/swhub-charts/poc/poc/5.2.0/ibm-namespace-scope-operator-4.2.13+20250227.220734.0.tgz
+    - https://raw.github.com/IBM/swhub-charts/poc/5.2.0/ibm-namespace-scope-operator-4.2.13+20250227.220734.0.tgz
     version: 4.2.13+20250227.220734.0
   ibm-namespace-scope-operator-cluster-scoped:
   - apiVersion: v2


### PR DESCRIPTION
Problem : url for `ibm-namespace-scope-operator-4.2.13+20250227.220734.0.tgz` is not correct.
```
helm repo list
NAME         	URL
cpd-helm-repo	https://raw.githubusercontent.com/IBM/swhub-charts/poc/5.2.0

helm pull cpd-helm-repo/ibm-namespace-scope-operator cpd-helm-repo/ibm-namespace-scope-operator-cluster-scoped --version $nssVer
Error: failed to fetch https://raw.github.com/IBM/swhub-charts/poc/poc/5.2.0/ibm-namespace-scope-operator-4.2.13+20250227.220734.0.tgz : 404 Not Found
```

Testing :
```
» chartRepo=https://raw.githubusercontent.com/daezaa/swhub-charts/poc/5.2.0
»   helm repo add cpd-helm-repo $chartRepo                                 
"cpd-helm-repo" has been added to your repositories
» nssVer=4.2.13+20250227.220734.0
» helm pull cpd-helm-repo/ibm-namespace-scope-operator cpd-helm-repo/ibm-namespace-scope-operator-cluster-scoped --version $nssVer
» ls | grep cluster
ibm-namespace-scope-operator-cluster-scoped-4.2.13+20250227.220734.0.tgz
```
